### PR TITLE
Fix crash with picker dollies rotate

### DIFF
--- a/scripts/other-mods/picker-dollies.lua
+++ b/scripts/other-mods/picker-dollies.lua
@@ -8,7 +8,10 @@ local PickerDollies = {}
 
 --- Move the output after moving stack combinator
 local function moved(ev)
-  This.runtime:sc(ev.moved_entity):moved()
+  local sc = This.runtime:sc(ev.moved_entity)
+  assert(sc.run)
+  sc:moved()
+  return sc
 end
 
 --- Wire up the event handler
@@ -27,8 +30,8 @@ local function register()
       -- Figuring out which entity was being rotated would require accessing PD's game data etc., so
       -- instead let's just ensure *all* StaCos are lined up with their outputs
       for _, sc in pairs(global.combinators) do
-        moved({ moved_entity = sc.input })
-        sc:rotated()
+        local moved_sc = moved({ moved_entity = sc.input })
+        moved_sc:rotated()
       end
     end)
 


### PR DESCRIPTION
When rotating an entity (any entity) before the stack combinator has rebuilt the internal data structures,
it crashes the game because it could not find the `sc:rotated()` method. As the code already re-registers
the combinator in the `moved(ev)` method, return the sc from there and rotate it.

This is a *mostly* theoretical crash because the tick handler will fix up the internal data structures
before anyone can press the Picker Dollies "rotate" key. However, in the map editor, when time is stopped,
pressing that button leads to an instant crash (and rotating *any* entity crashes the game).
